### PR TITLE
chore: update hookable to v6

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ catalogs:
       version: 2.13.1
   prod:
     hookable:
-      specifier: ^5.5.3
-      version: 5.5.3
+      specifier: ^6.0.1
+      version: 6.0.1
     pathe:
       specifier: ^2.0.3
       version: 2.0.3
@@ -80,7 +80,7 @@ importers:
         version: 1.4.1
       hookable:
         specifier: catalog:prod
-        version: 5.5.3
+        version: 6.0.1
       pathe:
         specifier: catalog:prod
         version: 2.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ catalogs:
     lint-staged: ^16.2.7
     simple-git-hooks: ^2.13.1
   prod:
-    hookable: ^5.5.3
+    hookable: ^6.0.1
     pathe: ^2.0.3
     std-env: ^3.10.0
     yaml: ^2.7.0


### PR DESCRIPTION
## What
- update the `prod` catalog entry for `hookable` from `^5.5.3` to `^6.0.1`
- refresh `pnpm-lock.yaml` so workspace importer resolves `hookable` to `6.0.1`

## Validation
- pnpm typecheck
- pnpm test -- --run
