### PR TITLE
fix(docs): expand vector sidebar

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -4,3 +4,6 @@ node_modules
 dist
 .vercel
 .env*.local
+
+# Prevent accidental cache folders from `undocs dev` arg mistakes (host/port folders)
+*/.docs/

--- a/docs/3.features/40.vector/.navigation.yml
+++ b/docs/3.features/40.vector/.navigation.yml
@@ -1,2 +1,3 @@
 title: Vector
 icon: i-lucide-vector-square
+defaultOpen: true


### PR DESCRIPTION
Fixes docs sidebar where **Vector** section could appear collapsed/non-expandable when navigation is non-collapsible.

Changes:
- Force Vector nav group to be open by default (defaultOpen: true).
- Ignore accidental */.docs/ folders created by mis-invoked undocs dev.

Repro: open /features and ensure Vector shows its child pages.