### PR TITLE
fix: skill paths + runtime detection

### DIFF
--- a/docs/2.core/19.skill.md
+++ b/docs/2.core/19.skill.md
@@ -156,8 +156,8 @@ interface InstallSkillOptions {
   source: string // GitHub repo, URL, or local path
   skills?: string[] // Filter to specific skills
   agents?: string[] // Target agents (auto-detects if omitted)
-  global?: boolean // Install to global config (default: true)
-  cwd?: string // Working directory for local installs
+  cwd?: string // Working directory for relative local sources
+  global?: boolean // Reserved for future local/project installs (currently ignored)
   mode?: 'symlink' | 'copy' // Link mode (default: 'symlink')
 }
 
@@ -170,8 +170,8 @@ interface InstallSkillResult {
 interface UninstallSkillOptions {
   skill: string // Skill name to remove
   agents?: string[] // Target agents (auto-detects if omitted)
-  global?: boolean // Uninstall from global config
-  cwd?: string // Working directory
+  cwd?: string // Reserved (currently ignored)
+  global?: boolean // Reserved for future local/project installs (currently ignored)
 }
 
 interface UninstallSkillResult {

--- a/src/fs/index.ts
+++ b/src/fs/index.ts
@@ -253,13 +253,15 @@ export class RealFS implements VirtualFS {
   private normalizedBase: string
 
   constructor(private basePath: string = '/') {
-    this.normalizedBase = normalize(basePath)
+    // Normalize once; treat '/' as a special case.
+    const n = normalize(basePath)
+    this.normalizedBase = n === '/' ? '/' : n.replace(/\/+$/, '')
   }
 
   private resolve(path: string): string {
     const resolved = normalize(join(this.basePath, path))
     // Prevent path traversal attacks
-    if (!resolved.startsWith(this.normalizedBase) && resolved !== this.normalizedBase)
+    if (this.normalizedBase !== '/' && resolved !== this.normalizedBase && !resolved.startsWith(`${this.normalizedBase}/`))
       throw new Error(`EACCES: path traversal not allowed: ${path}`)
     return resolved
   }

--- a/src/skill/uninstall.ts
+++ b/src/skill/uninstall.ts
@@ -11,7 +11,9 @@ const SKILL_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/
 export interface UninstallSkillOptions {
   skill: string
   agents?: string[]
+  /** Reserved for future local/project uninstalls (currently ignored). */
   global?: boolean
+  /** Reserved for future local/project uninstalls (currently ignored). */
   cwd?: string
 }
 


### PR DESCRIPTION
## Summary
- Expand `~` in `discoverSkills()` so docs/README examples work as-written
- Harden `RealFS` traversal check (prefix bypass)
- Make `detect*()` safe in non-Node runtimes and improve `is*Available()` resolution for ESM
- Harden `installSkill` (path containment + proper temp cleanup) and align docs for reserved options

## Tests
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test --run`