### PR TITLE
fix(playground): guard unavailable providers

### DIFF
--- a/playground/server/_shared/providers.ts
+++ b/playground/server/_shared/providers.ts
@@ -1,5 +1,5 @@
 import type { H3Event } from 'h3'
-import { getProvider } from './provider'
+import { getCloudflareEnv, getProvider } from './provider'
 
 export interface ProviderEntry {
   id: string
@@ -7,6 +7,7 @@ export interface ProviderEntry {
   runtimeOnly?: string
   envRequired?: string[]
   runtimeOrEnv?: string // available natively on this runtime, or via env vars on any runtime
+  cloudflareBindingsRequired?: string[]
 }
 
 export interface ProviderAvailability extends ProviderEntry {
@@ -16,18 +17,18 @@ export interface ProviderAvailability extends ProviderEntry {
 
 export const providerRegistry: Record<string, ProviderEntry[]> = {
   sandbox: [
-    { id: 'cloudflare', label: 'Cloudflare', runtimeOnly: 'cloudflare' },
+    { id: 'cloudflare', label: 'Cloudflare', runtimeOnly: 'cloudflare', cloudflareBindingsRequired: ['SANDBOX'] },
     { id: 'vercel', label: 'Vercel', runtimeOrEnv: 'vercel', envRequired: ['VERCEL_TOKEN', 'VERCEL_TEAM_ID', 'VERCEL_PROJECT_ID'] },
     { id: 'deno', label: 'Deno', envRequired: ['DENO_DEPLOY_TOKEN'] },
   ],
   queue: [
-    { id: 'cloudflare', label: 'Cloudflare', runtimeOnly: 'cloudflare' },
+    { id: 'cloudflare', label: 'Cloudflare', runtimeOnly: 'cloudflare', cloudflareBindingsRequired: ['MY_QUEUE'] },
     { id: 'vercel', label: 'Vercel', runtimeOnly: 'vercel' },
     { id: 'qstash', label: 'QStash', envRequired: ['QSTASH_TOKEN'] },
     { id: 'memory', label: 'Memory' },
   ],
   workflow: [
-    { id: 'cloudflare', label: 'Cloudflare', runtimeOnly: 'cloudflare' },
+    { id: 'cloudflare', label: 'Cloudflare', runtimeOnly: 'cloudflare', cloudflareBindingsRequired: ['MY_WORKFLOW'] },
     { id: 'vercel', label: 'Vercel', runtimeOnly: 'vercel' },
     { id: 'openworkflow', label: 'OpenWorkflow', envRequired: ['DATABASE_URL'] },
   ],
@@ -35,7 +36,7 @@ export const providerRegistry: Record<string, ProviderEntry[]> = {
     { id: 'node', label: 'Node' },
   ],
   vector: [
-    { id: 'cloudflare', label: 'Cloudflare', runtimeOnly: 'cloudflare' },
+    { id: 'cloudflare', label: 'Cloudflare', runtimeOnly: 'cloudflare', cloudflareBindingsRequired: ['VECTORIZE'] },
     { id: 'upstash', label: 'Upstash', envRequired: ['UPSTASH_VECTOR_URL', 'UPSTASH_VECTOR_TOKEN'] },
     { id: 'pinecone', label: 'Pinecone', envRequired: ['PINECONE_API_KEY'] },
     { id: 'qdrant', label: 'Qdrant', envRequired: ['QDRANT_URL'] },
@@ -49,6 +50,14 @@ export const providerRegistry: Record<string, ProviderEntry[]> = {
 export function isAvailable(entry: ProviderEntry, runtime: string, _event: H3Event): { available: boolean, reason?: string } {
   if (entry.runtimeOnly && entry.runtimeOnly !== runtime)
     return { available: false, reason: `Requires ${entry.runtimeOnly} runtime` }
+
+  if (runtime === 'cloudflare' && entry.cloudflareBindingsRequired?.length) {
+    const env = getCloudflareEnv(_event) as Record<string, unknown> | null
+    const missing = entry.cloudflareBindingsRequired.filter(k => !env?.[k])
+    if (missing.length)
+      return { available: false, reason: `Missing Cloudflare binding: ${missing.join(', ')}` }
+  }
+
   if (entry.runtimeOrEnv && entry.runtimeOrEnv === runtime)
     return { available: true }
   if (entry.envRequired) {


### PR DESCRIPTION
## Summary
- guard Cloudflare providers by required bindings in the providers matrix (`SANDBOX`, `MY_WORKFLOW`, `MY_QUEUE`, `VECTORIZE`)
- return explicit unavailability reasons instead of showing runtime-only providers as available
- guard `/api/sandbox/:provider/files` when file operations are unsupported and return a structured 400 instead of a 500

## Tests
- `pnpm eslint playground/server/_shared/providers.ts "playground/routes/api/sandbox/[provider]/files.get.ts"`
- `pnpm --filter unagent-playground build:vercel`
- `pnpm --filter unagent-playground build:cf`

## Prod Playground Checklist (2026-02-11)
- [x] Vercel deployed (`https://playground-one-tawny.vercel.app`) and `GET /api/health` + `GET /api/providers` pass.
- [x] Cloudflare deployed (`https://nuxthub-agent-playground.maximogarciamtnez.workers.dev`) and `GET /api/health` + `GET /api/providers` pass.
- [x] Compatibility routes `/sandbox`, `/vector`, `/api/sandbox` return 200/ok.
- [x] Vercel workflow lifecycle `start -> status -> stop` passes.
- [x] Sandbox checks pass: `GET /api/sandbox/cloudflare/files` works and `GET /api/sandbox/vercel/files` returns structured `400` (no `500`).
- [x] Vercel queue/task/cron smoke tests pass: queue memory `send/peek/drain`, task `list/run`, cron memory `create/get/pause/resume/delete`.
- [ ] `workflow/cloudflare` missing CF binding `MY_WORKFLOW`.
- [ ] `queue/cloudflare` missing CF binding `MY_QUEUE`.
- [ ] `vector/cloudflare` missing CF binding `VECTORIZE`.
- [ ] `queue/qstash` missing env `QSTASH_TOKEN`.
- [ ] `vector/pinecone` missing env `PINECONE_API_KEY`.
- [ ] `vector/qdrant` missing env `QDRANT_URL`.
- [ ] `vector/weaviate` missing env `WEAVIATE_URL`.
- [ ] `vector/pgvector` missing env `DATABASE_URL`.
- [ ] `vector/libsql` missing env `LIBSQL_URL`.
- [ ] `workflow/openworkflow` missing `DATABASE_URL` (plus runtime/package constraints on Cloudflare).
- [ ] `sandbox/deno` missing `DENO_DEPLOY_TOKEN` (plus runtime/package constraints).

## Related
- [nuxt-hub/agent#10](https://github.com/nuxt-hub/agent/pull/10)